### PR TITLE
enhance: specify health as system requirement

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -27,7 +27,7 @@
 
       <SystemSetting Name="CSP.DefaultFileCharset" Value="UTF-8"/>
       <CSPApplication Url="/appealai" SourcePath="/dist/ui/browser" DeployPath="{$cspdir}/appealai" ServeFiles="1" Recurse="1" CookiePath="/appealai"/>      
-      <SystemRequirements Interoperability="enabled" />
+      <SystemRequirements Interoperability="enabled" Health="true"/>
       <Dependencies>
         <ModuleReference>
           <Name>bg-openai</Name>


### PR DESCRIPTION
Hi there, 

InterSystems is rolling out a [newer version](https://github.com/intersystems/ipm/tree/v1) of package manager that allows package contributors to declare their package requires healthcare/healthconnect/iris for health. With this change, a user will get a descriptive warning:
```
ERROR! The module requires InterSystems IRIS for Health, HealthConnect, or HealthShare. Current system is not compatible.
```
when trying to install the package on incompatible systems with the new package manager.

This change is also backward compatible.